### PR TITLE
add synchronization around removeGauge/addGauge 

### DIFF
--- a/src/main/scala/com/twitter/finagle/metrics/MetricsStatsReceiver.scala
+++ b/src/main/scala/com/twitter/finagle/metrics/MetricsStatsReceiver.scala
@@ -13,16 +13,21 @@ object MetricsStatsReceiver {
   }
 
   private[metrics] case class MetricGauge(name: String)(f: => Float) extends Gauge {
-    // remove old gauge's value before adding a new one
-    metrics.getGauges(new MetricFilter() {
-      override def matches(metricName: String, metric: Metric): Boolean =
-        metricName == name
-    }).asScala
-      .foreach { case (gaugeName, _) => metrics.remove(gaugeName) }
+    // we need to synchronize so this is safe with multiple threads. Ideally the callers are themselves
+    // synchronized so they don't overwrite each others gauges but until they are we should protect
+    // ourselves from that race condition.
+    synchronized {
+      // remove old gauge's value before adding a new one
+      metrics.getGauges(new MetricFilter() {
+        override def matches(metricName: String, metric: Metric): Boolean =
+          metricName == name
+      }).asScala
+        .foreach { case (gaugeName, _) => metrics.remove(gaugeName) }
 
-    metrics.register(name, new MGauge[Float]() {
-      override def getValue(): Float = f
-    })
+      metrics.register(name, new MGauge[Float]() {
+        override def getValue(): Float = f
+      })
+    }
 
     override def remove(): Unit = metrics.remove(name)
   }


### PR DESCRIPTION
Prevents exceptions during startup

Also done on another fork of project but not PRed

https://github.com/spredfast/finagle-metrics/commit/e03d5aeb2c6e751c5fcee6addef693ef6c6df901

```
[2017-05-03 21:38:00,164] ERROR Internal Server Error (com.signalpath.module.exception.DefaultExceptionMapper:116)
java.lang.IllegalArgumentException: A metric named clnt.localhost:4444.dispatcher.serial.queue_size already exists
	at com.codahale.metrics.MetricRegistry.register(MetricRegistry.java:91)
	at com.twitter.finagle.metrics.MetricsStatsReceiver$MetricGauge.<init>(MetricsStatsReceiver.scala:23)
	at com.twitter.finagle.metrics.MetricsStatsReceiver.addGauge(MetricsStatsReceiver.scala:46)
	at com.twitter.finagle.stats.BroadcastStatsReceiver$Two$$anon$1.<init>(BroadcastStatsReceiver.scala:27)
	at com.twitter.finagle.stats.BroadcastStatsReceiver$Two.addGauge(BroadcastStatsReceiver.scala:26)
	at com.twitter.finagle.stats.StatsReceiverProxy$class.addGauge(StatsReceiverProxy.scala:10)
	at com.twitter.finagle.stats.LoadedStatsReceiver$.addGauge(LoadedStatsReceiver.scala:9)
	at com.twitter.finagle.stats.NameTranslatingStatsReceiver.addGauge(NameTranslatingStatsReceiver.scala:32)
	at com.twitter.finagle.stats.StatsReceiverProxy$class.addGauge(StatsReceiverProxy.scala:10)
	at com.twitter.finagle.stats.ClientStatsReceiver$.addGauge(LoadedStatsReceiver.scala:46)
	at com.twitter.finagle.stats.NameTranslatingStatsReceiver.addGauge(NameTranslatingStatsReceiver.scala:32)
	at com.twitter.finagle.stats.NameTranslatingStatsReceiver.addGauge(NameTranslatingStatsReceiver.scala:32)
	at com.twitter.finagle.stats.NameTranslatingStatsReceiver.addGauge(NameTranslatingStatsReceiver.scala:32)
	at com.twitter.finagle.dispatch.GenSerialClientDispatcher.<init>(ClientDispatcher.scala:27)
	at com.twitter.finagle.http.codec.HttpClientDispatcher.<init>(HttpClientDispatcher.scala:25)
	at com.twitter.finagle.Http$Client.newDispatcher(Http.scala:191)
```